### PR TITLE
fix: deprecated syntax

### DIFF
--- a/src/UUID.php
+++ b/src/UUID.php
@@ -106,7 +106,7 @@ class UUID
     {
         $hex = '';
         for ($i = 0; $i < strlen($ascii); $i++) {
-            $byte = strtoupper(dechex(ord($ascii{$i})));
+            $byte = strtoupper(dechex(ord($ascii[$i])));
             $byte = str_repeat('0', 2 - strlen($byte)) . $byte;
             $hex  .= $byte . "";
         }


### PR DESCRIPTION
```
ErrorException
Array and string offset access syntax with curly braces is deprecated
```